### PR TITLE
Fix `testpack-cli` tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run test
-      - run: npx testpack-cli --keep={@types/jest,ts-jest,typescript} src/e2e.spec.ts
+      - run: npx testpack-cli --keep=@types/jest,ts-jest,typescript src/e2e.spec.ts
 
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run test
-      - run: npx testpack-cli --keep={ts-jest,typescript} src/e2e.spec.ts
+      - run: npx testpack-cli --keep={@types/jest,ts-jest,typescript} src/e2e.spec.ts
 
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Fix `testpack-cli` tests failing during [last scheduled run](https://github.com/wimpyprogrammer/strings-to-regex/actions/runs/626062422).

> Test suite failed to run
>
>    src/e2e.spec.ts:3:1 - error TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.