### PR TITLE
Drop support for Node 14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [16.x]
-        require-successful-testpack: [true]
         include:
           - node-version: 18.x
-            require-successful-testpack: false
           - node-version: lts/*
-            require-successful-testpack: false
 
     steps:
       - name: Checkout repository
@@ -45,8 +42,6 @@ jobs:
 
       - run: npx testpack-cli --keep=@types/jest,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
         working-directory: ./packages/strings-to-regex
-        # Workaround for #76
-        continue-on-error: ${{ !matrix.require-successful-testpack }}
 
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v5.4.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         require-successful-testpack: [true]
         include:
-          - node-version: 16.x
+          - node-version: 18.x
             require-successful-testpack: false
           - node-version: lts/*
             require-successful-testpack: false

--- a/packages/strings-to-regex/package.json
+++ b/packages/strings-to-regex/package.json
@@ -18,7 +18,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "scripts": {
     "build": "tsc -b --clean && tsc -b",


### PR DESCRIPTION
Node 14 reached end-of-life on April 30, 2023.

Also require that `testpack-cli` succeed for all Node versions.  The workaround added in #76 appears to be no longer necessary.