### PR TITLE
Drop support for Node 16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         include:
-          - node-version: 18.x
+          - node-version: 20.x
+          - node-version: 22.x
           - node-version: lts/*
 
     steps:

--- a/packages/strings-to-regex/package.json
+++ b/packages/strings-to-regex/package.json
@@ -18,7 +18,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "build": "tsc -b --clean && tsc -b",


### PR DESCRIPTION
Node 16 reached EOL on 11 Sep 2023.